### PR TITLE
Hotfix deprecate nf validate plugin

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -15,7 +15,7 @@ nextflow.enable.dsl = 2
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 */
 
-include { validateParameters; } from 'plugin/nf-validation'
+include { validateParameters; } from 'plugin/nf-schema'
 validateParameters()
 
 /*

--- a/nextflow.config
+++ b/nextflow.config
@@ -22,7 +22,7 @@ plugins {
 
 // Global default params, used in configs
 params {
-    //genome = '/hpc/diaggen/data/databases/ref_genomes/Homo_sapiens.GRCh37.GATK.illumina/Homo_sapiens.GRCh37.GATK.illumina.fasta'
+    genome = '/hpc/diaggen/data/databases/ref_genomes/Homo_sapiens.GRCh37.GATK.illumina/Homo_sapiens.GRCh37.GATK.illumina.fasta'
 
     // Input options
     input = null
@@ -39,7 +39,7 @@ params {
 process.shell = ['/bin/bash', '-euo', 'pipefail']
 
 // Load base.config
-//includeConfig 'conf/base.config'
+includeConfig 'conf/base.config'
 
 // Load modules.config for module specific options
 includeConfig 'conf/modules.config'

--- a/nextflow.config
+++ b/nextflow.config
@@ -17,12 +17,12 @@ manifest {
 
 // Nextflow plugins
 plugins {
-    id 'nf-validation' // Validation of pipeline parameters and creation of an input channel from a sample sheet
+    id 'nf-schema@2.0.0' // Validation of pipeline parameters and creation of an input channel from a sample sheet
 }
 
 // Global default params, used in configs
 params {
-    genome = '/hpc/diaggen/data/databases/ref_genomes/Homo_sapiens.GRCh37.GATK.illumina/Homo_sapiens.GRCh37.GATK.illumina.fasta'
+    //genome = '/hpc/diaggen/data/databases/ref_genomes/Homo_sapiens.GRCh37.GATK.illumina/Homo_sapiens.GRCh37.GATK.illumina.fasta'
 
     // Input options
     input = null
@@ -39,7 +39,7 @@ params {
 process.shell = ['/bin/bash', '-euo', 'pipefail']
 
 // Load base.config
-includeConfig 'conf/base.config'
+//includeConfig 'conf/base.config'
 
 // Load modules.config for module specific options
 includeConfig 'conf/modules.config'

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -1,10 +1,10 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://raw.githubusercontent.com/UMCUGenetics/WorkflowName/master/nextflow_schema.json",
   "title": "UMCUGenetics/WorkflowName pipeline parameters",
   "description": "UMCU Genetics RNA Workflow",
   "type": "object",
-  "definitions": {
+  "defs": {
     "input_output_options": {
       "title": "Input/output options",
       "type": "object",
@@ -73,13 +73,13 @@
   },
   "allOf": [
     {
-      "$ref": "#/definitions/input_output_options"
+      "$ref": "#/defs/input_output_options"
     },
     {
-      "$ref": "#/definitions/reference_genome_options"
+      "$ref": "#/defs/reference_genome_options"
     },
     {
-      "$ref": "#/definitions/generic_options"
+      "$ref": "#/defs/generic_options"
     }
   ]
 }


### PR DESCRIPTION
Small change to the nf-core template to replace the now deprecated plugin/nf-validate (used in `validateParamters`) with the successor plugin/nf-scheme.